### PR TITLE
Fix Windows Compilation by Adding Missing winapi Dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,6 +44,10 @@ image = "0.24.7"   # Image loading and manipulation
 # For macOS bundling
 cargo-bundle = "0.6.0"
 
+# For windows bundling
+[target.'cfg(windows)'.dependencies]
+winapi = { version = "0.3.5", features = ["winuser"] }
+
 [dev-dependencies]
 
 [profile.release]


### PR DESCRIPTION
#### Description  
This PR fixes a compilation issue on Windows by adding the `winapi` crate with the `winuser` feature.  

#### Issue  
- The function `fn set_app_icon_windows(icon_data: &IconData) -> AppIconStatus` in `app_icon.rs` (within `eframe` native) depends on `winapi::um::winuser`.  
- However, `winapi` was missing as a dependency, causing the build to fail on Windows.  

#### Solution  
- Added `winapi` with the `winuser` feature to `Cargo.toml` to ensure the necessary symbols are available at compile time.  
- Updated `Cargo.lock` accordingly.  